### PR TITLE
Update the gh dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,11 @@
         "mocha": "1.12.0"
     },
     "peerDependencies": {
-        "gh": ">=1.4.0"
+        "gh": ">=1.9"
     },
     "engines": {
         "node": ">=0.8"
     },
     "preferGlobal": "true"
 }
+


### PR DESCRIPTION
When trying to update gh to the new version:

`
npm ERR! peerinvalid The package gh does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer dotfiles@0.5.0 wants gh@~1.8.2
npm ERR! peerinvalid Peer gh-gif@0.1.3 wants gh@>=1.4.0
npm ERR! peerinvalid Peer gh-jira@0.4.3 wants gh@>=1.8.0`
