### PR TITLE
Fix query for phrases and add --best and --bestof options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Option             | Usage        | Type
 ---                | ---          | ---
 `-n`, `--number`   | **Required** | `Number`
 `-R`, `--reaction` | **Required** | `String`
+`-b`, `--best`     | *Optional*   | `Boolean`
 `-i`, `--image`    | *Optional*   | `String`
 `-r`, `--repo`     | *Optional*   | `String`
 `-u`, `--user`     | *Optional*   | `String`
@@ -57,6 +58,12 @@ gh gif 75 --image http://media1.giphy.com/media/5DQdk5oZzNgGc/original.gif
 	```
 gh gif --reaction happy --number 1 --number 2
 	```
+
+* Comment on pull request/issue #75 with the best search result
+
+    ```
+gh gif 75 --reaction happy --best
+    ```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Option             | Usage        | Type
 `-n`, `--number`   | **Required** | `Number`
 `-R`, `--reaction` | **Required** | `String`
 `-b`, `--best`     | *Optional*   | `Boolean`
+`-B`, `--bestof`   | *Optional*   | `Number`
 `-i`, `--image`    | *Optional*   | `String`
 `-r`, `--repo`     | *Optional*   | `String`
 `-u`, `--user`     | *Optional*   | `String`
@@ -63,6 +64,12 @@ gh gif --reaction happy --number 1 --number 2
 
     ```
 gh gif 75 --reaction happy --best
+    ```
+
+* Comment on pull request/issue #75 with a random GIF of the first three result items.
+
+    ```
+gh gif 75 --reaction happy --bestof 3
     ```
 
 ## Testing

--- a/bin/gif.js
+++ b/bin/gif.js
@@ -40,6 +40,7 @@ Gif.DETAILS = {
         'number': [Number, Array],
         'reaction': String,
         'best': Boolean,
+        'bestof': Number,
         'repo': String,
         'user': String
     },
@@ -48,6 +49,7 @@ Gif.DETAILS = {
         'n': [ '--number' ],
         'R': [ '--reaction' ],
         'b': [ '--best' ],
+        'B': [ '--bestof' ],
         'r': [ '--repo' ],
         'u': [ '--user' ]
     },
@@ -99,6 +101,10 @@ Gif.prototype.image = function(image, opt_callback) {
     async.series(operations, opt_callback);
 };
 
+Gif.prototype.getRandomItem = function (array) {
+    return array[Math.floor(Math.random() * array.length)];
+};
+
 Gif.prototype.reaction = function(opt_callback) {
     var instance = this,
         options = instance.options,
@@ -113,8 +119,12 @@ Gif.prototype.reaction = function(opt_callback) {
 
                     if (options.best) {
                         options.image = result[0].images.original.url;
+                    } else if (options.bestof > 0) {
+                        result = result.slice(0, options.bestof);
+                        random = instance.getRandomItem(result);
+                        options.image = random.images.original.url;
                     } else {
-                        random = result[Math.floor(Math.random() * result.length)];
+                        random = instance.getRandomItem(result);
                         options.image = random.images.original.url;
                     }
                 }

--- a/bin/gif.js
+++ b/bin/gif.js
@@ -39,6 +39,7 @@ Gif.DETAILS = {
         'image': String,
         'number': [Number, Array],
         'reaction': String,
+        'best': Boolean,
         'repo': String,
         'user': String
     },
@@ -46,6 +47,7 @@ Gif.DETAILS = {
         'i': [ '--image' ],
         'n': [ '--number' ],
         'R': [ '--reaction' ],
+        'b': [ '--best' ],
         'r': [ '--repo' ],
         'u': [ '--user' ]
     },
@@ -108,8 +110,13 @@ Gif.prototype.reaction = function(opt_callback) {
             giphy.search(encodeURIComponent(options.reaction), 50, 0, function(err, result) {
                 if (!err) {
                     result = result.data;
-                    random = result[Math.floor(Math.random() * result.length)];
-                    options.image = random.images.original.url;
+
+                    if (options.best) {
+                        options.image = result[0].images.original.url;
+                    } else {
+                        random = result[Math.floor(Math.random() * result.length)];
+                        options.image = random.images.original.url;
+                    }
                 }
                 callback(err);
             });

--- a/bin/gif.js
+++ b/bin/gif.js
@@ -105,7 +105,7 @@ Gif.prototype.reaction = function(opt_callback) {
 
     operations = [
         function(callback) {
-            giphy.search(options.reaction, 50, 0, function(err, result) {
+            giphy.search(encodeURIComponent(options.reaction), 50, 0, function(err, result) {
                 if (!err) {
                     result = result.data;
                     random = result[Math.floor(Math.random() * result.length)];


### PR DESCRIPTION
Basically with this you can:

* Search with more words
`gh gif 3 -R "Jim Carrey Dancing"`

* Choose to use the best result (The index 0)
`gh gif 3 -R "Jim Carrey Dancing" --best`

* And specify how much items consider in the random
`gh gif 3 -R "Jim Carrey Dancing" --bestof 3` (Will use one of the first three results)

I have no idea if `--bestof` is a good name, because we are not choosing the best of the first N items, its random... but I could not think in any other better name.`